### PR TITLE
Fix encoding errors in script comments

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,10 +52,10 @@ function addFlashcard(event) {
     saveFlashcards(cards);
     renderList();
     event.target.reset();
-    renderFields(type); // Reiniciar campos segÃºn tipo
+    renderFields(type); // Reiniciar campos según tipo
 }
 
-// Elimina una tarjeta por Ã­ndice
+// Elimina una tarjeta por índice
 function deleteFlashcard(index) {
     const cards = loadFlashcards();
     cards.splice(index, 1);


### PR DESCRIPTION
## Summary
- correct typos due to mis-encoded characters in script.js comments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685496ee4fc083259ecc3d2b1d461af7