### PR TITLE
Add package.json and update README usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Para probar la aplicación solo abre `index.html` en tu navegador.
 
 ## Instalación
 
-Puedes usar un servidor estático para ejecutar la aplicación de forma local. Si tienes Node.js instalado, una opción sencilla es `npx serve`:
+Instala las dependencias del proyecto y ejecuta el servidor incluido con los siguientes comandos:
 
 ```bash
-npx serve
+npm install
+npm start
 ```
 
-Abre el navegador en la dirección que indique la terminal para acceder a la app.
+Esto iniciará `serve` sobre la carpeta actual. Abre el navegador en la dirección que indique la terminal para acceder a la app.
 
 ## Licencia
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "proyecto_v1",
+  "version": "1.0.0",
+  "description": "Esta es una aplicación web sencilla para gestionar flashcards sin utilizar frameworks. Permite crear dos tipos de tarjetas:",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "serve ."
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "devDependencies": {
+    "serve": "^14.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` with `serve` as a dev dependency
- update README on how to install and start the project

## Testing
- `npm install` *(fails: 403 Forbidden, registry access blocked)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68549be7681c8325becd7b163c559414