### PR TITLE
Add deck management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Proyecto_V1
 
-Esta es una aplicación web sencilla para gestionar flashcards sin utilizar frameworks. Permite crear dos tipos de tarjetas:
+Esta es una aplicación web sencilla para gestionar flashcards y mazos sin utilizar frameworks. Permite crear dos tipos de tarjetas:
 
 - **Clásica**: contiene pregunta y respuesta.
 - **Falso/Verdadero**: contiene un enunciado y una marca que indica si es verdadero.
 
-Las tarjetas se almacenan en `localStorage` para que persistan entre recargas del navegador.
+Las tarjetas se agrupan en *mazos* que también se guardan en `localStorage` para que persistan entre recargas del navegador.
 
 ## Estructura
 
 - `index.html` contiene la estructura básica de la página y el formulario.
 - `style.css` define el aspecto de la interfaz.
-- `script.js` implementa la lógica de creación, renderizado y eliminación de flashcards.
+- `script.js` implementa la lógica de creación de mazos y tarjetas, su renderizado y eliminación.
 
 Para probar la aplicación solo abre `index.html` en tu navegador.
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
 <body>
     <h1>Gestor de Flashcards</h1>
 
+    <div id="deck-controls">
+        <select id="deck-select"></select>
+        <button id="add-deck">Nuevo mazo</button>
+        <button id="rename-deck">Renombrar</button>
+        <button id="delete-deck">Eliminar mazo</button>
+    </div>
+
     <form id="flashcard-form">
         <label for="type">Tipo de tarjeta:</label>
         <select id="type" name="type">

--- a/script.js
+++ b/script.js
@@ -1,20 +1,37 @@
-// Utilidades para acceder a localStorage
-function loadFlashcards() {
-    const data = localStorage.getItem('flashcards');
-    if (!data) return [];
+// ----- Gestión de mazos -----
+function loadDecks() {
+    const data = localStorage.getItem('decks');
+    if (!data) return [{ name: 'Mazo 1', cards: [] }];
     try {
-        return JSON.parse(data);
+        const decks = JSON.parse(data);
+        if (Array.isArray(decks) && decks.length > 0) {
+            return decks;
+        }
+        return [{ name: 'Mazo 1', cards: [] }];
     } catch (e) {
-        return [];
+        return [{ name: 'Mazo 1', cards: [] }];
     }
 }
 
-function saveFlashcards(cards) {
-    localStorage.setItem('flashcards', JSON.stringify(cards));
+function saveDecks(decks) {
+    localStorage.setItem('decks', JSON.stringify(decks));
 }
 
-// Índice de tarjeta en modo edición, null si se está creando una nueva
-let editingIndex = null;
+let currentDeckIndex = 0;
+let editingIndex = null; // Índice de tarjeta en modo edición, null si nueva
+
+function loadFlashcards() {
+    const decks = loadDecks();
+    const deck = decks[currentDeckIndex] || { cards: [] };
+    return deck.cards;
+}
+
+function saveFlashcards(cards) {
+    const decks = loadDecks();
+    if (!decks[currentDeckIndex]) return;
+    decks[currentDeckIndex].cards = cards;
+    saveDecks(decks);
+}
 
 // Renderiza el formulario según el tipo de tarjeta seleccionado
 function renderFields(type) {
@@ -80,7 +97,10 @@ function deleteFlashcard(index) {
 
 // Borra todas las tarjetas almacenadas
 function clearAllFlashcards() {
-    localStorage.removeItem('flashcards');
+    const decks = loadDecks();
+    if (!decks[currentDeckIndex]) return;
+    decks[currentDeckIndex].cards = [];
+    saveDecks(decks);
     renderList();
 }
 
@@ -90,6 +110,61 @@ function updateClearButton() {
     if (btn) {
         btn.disabled = loadFlashcards().length === 0;
     }
+}
+
+// ----- Funciones para manejar mazos -----
+function renderDeckOptions() {
+    const select = document.getElementById('deck-select');
+    if (!select) return;
+    const decks = loadDecks();
+    select.innerHTML = '';
+    decks.forEach((deck, idx) => {
+        const opt = document.createElement('option');
+        opt.value = idx;
+        opt.textContent = deck.name;
+        select.appendChild(opt);
+    });
+    select.value = currentDeckIndex;
+}
+
+function createDeck() {
+    const name = prompt('Nombre del mazo:');
+    if (!name) return;
+    const decks = loadDecks();
+    decks.push({ name: name.trim(), cards: [] });
+    currentDeckIndex = decks.length - 1;
+    saveDecks(decks);
+    renderDeckOptions();
+    renderList();
+}
+
+function renameDeck() {
+    const decks = loadDecks();
+    const deck = decks[currentDeckIndex];
+    if (!deck) return;
+    const name = prompt('Nuevo nombre del mazo:', deck.name);
+    if (!name) return;
+    deck.name = name.trim();
+    saveDecks(decks);
+    renderDeckOptions();
+}
+
+function deleteDeck() {
+    const decks = loadDecks();
+    if (decks.length <= 1) return;
+    if (!confirm('¿Eliminar este mazo?')) return;
+    decks.splice(currentDeckIndex, 1);
+    if (currentDeckIndex >= decks.length) {
+        currentDeckIndex = decks.length - 1;
+    }
+    saveDecks(decks);
+    renderDeckOptions();
+    renderList();
+}
+
+function handleDeckChange(e) {
+    currentDeckIndex = parseInt(e.target.value, 10) || 0;
+    renderList();
 }
 
 // Carga una tarjeta en el formulario para editarla
@@ -177,6 +252,25 @@ function init() {
     if (clearBtn) {
         clearBtn.addEventListener('click', clearAllFlashcards);
     }
+
+    renderDeckOptions();
+    const deckSelect = document.getElementById('deck-select');
+    if (deckSelect) {
+        deckSelect.addEventListener('change', handleDeckChange);
+    }
+    const addDeckBtn = document.getElementById('add-deck');
+    if (addDeckBtn) {
+        addDeckBtn.addEventListener('click', createDeck);
+    }
+    const renameDeckBtn = document.getElementById('rename-deck');
+    if (renameDeckBtn) {
+        renameDeckBtn.addEventListener('click', renameDeck);
+    }
+    const deleteDeckBtn = document.getElementById('delete-deck');
+    if (deleteDeckBtn) {
+        deleteDeckBtn.addEventListener('click', deleteDeck);
+    }
+
     renderList();
 }
 

--- a/style.css
+++ b/style.css
@@ -46,3 +46,12 @@ button {
 .flashcard button {
     margin-top: 1rem;
 }
+
+#deck-controls {
+    margin-bottom: 1rem;
+}
+
+#deck-controls select,
+#deck-controls button {
+    margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- enable multiple decks with create, rename and delete controls
- update stylesheet for deck controls
- store deck data in localStorage and revise logic accordingly
- update README with new behavior

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68549f452760832594382577ece796fd