### PR TITLE
Fix flashcard form type selection on reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -67,6 +67,7 @@ function addFlashcard(event) {
     saveFlashcards(cards);
     renderList();
     event.target.reset();
+    document.getElementById('type').value = type; // mantener selección
     renderFields(type); // Reiniciar campos según tipo
 }
 


### PR DESCRIPTION
## Summary
- keep selected flashcard type after saving a card

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854a75c8428832589c414fbf92c4043