### PR TITLE
Add deck feature and minimal style update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Proyecto_V1
 
-Esta es una aplicación web sencilla para gestionar flashcards sin utilizar frameworks. Permite crear dos tipos de tarjetas:
+Esta es una aplicación web sencilla para gestionar flashcards sin utilizar frameworks. Ahora permite agrupar las tarjetas en **mazos** y crear dos tipos de tarjetas:
 
 - **Clásica**: contiene pregunta y respuesta.
 - **Falso/Verdadero**: contiene un enunciado y una marca que indica si es verdadero.
@@ -29,11 +29,12 @@ Esto iniciará `serve` sobre la carpeta actual. Abre el navegador en la direcci�
 ## Uso
 
 1. Selecciona el tipo de tarjeta y completa los campos del formulario.
-2. Pulsa **Guardar tarjeta** para almacenarla.
-3. En cada tarjeta aparecerán los botones **Editar** y **Eliminar**:
+2. Selecciona o crea un **mazo** para organizar tus tarjetas.
+3. Pulsa **Guardar tarjeta** para almacenarla.
+4. En cada tarjeta aparecerán los botones **Editar** y **Eliminar**:
    - **Editar** carga la tarjeta en el formulario para modificarla; al guardar se reemplaza la versión anterior.
    - **Eliminar** borra únicamente esa tarjeta de la lista.
-4. El botón **Eliminar todas** elimina todas las tarjetas guardadas en `localStorage`.
+5. El botón **Eliminar todas** elimina todas las tarjetas guardadas en `localStorage`.
 
 ## Licencia
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <div class="container">
     <h1>Gestor de Flashcards</h1>
 
     <form id="flashcard-form">
@@ -15,6 +16,12 @@
             <option value="classic">Clásica</option>
             <option value="tf">Falso/Verdadero</option>
         </select>
+        <label for="deck">Mazo:</label>
+        <select id="deck" name="deck"></select>
+        <div class="new-deck">
+            <input type="text" id="new-deck" placeholder="Nuevo mazo">
+            <button type="button" id="add-deck">Añadir</button>
+        </div>
         <div id="dynamic-fields"><!-- Campos dinámicos se insertarán aquí --></div>
         <button type="submit">Guardar tarjeta</button>
     </form>
@@ -22,7 +29,7 @@
     <h2>Listado de Flashcards</h2>
     <button id="clear-all">Eliminar todas</button>
     <ul id="flashcard-list"></ul>
-
+    </div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,12 @@
 body {
-    font-family: Arial, sans-serif;
+    font-family: system-ui, sans-serif;
     margin: 2rem;
     background-color: #f5f5f5;
+}
+
+.container {
+    max-width: 800px;
+    margin: auto;
 }
 
 form {
@@ -28,6 +33,21 @@ input[type="text"], select {
 button {
     padding: 0.5rem 1rem;
     cursor: pointer;
+    border: none;
+    border-radius: 4px;
+    background-color: #1976d2;
+    color: #fff;
+}
+
+.new-deck {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.new-deck input[type="text"] {
+    flex: 1;
 }
 
 


### PR DESCRIPTION
## Summary
- implement deck ("mazo") management stored in localStorage
- allow creating new decks via the form
- show deck for each flashcard and preserve on edit
- redesign layout for a cleaner look
- document new deck usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854ad141320832586f0a284014f4b5d