### PR TITLE
Refactor flashcard app into ES modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Las tarjetas se almacenan en `localStorage` para que persistan entre recargas de
 
 - `index.html` contiene la estructura básica de la página y el formulario.
 - `style.css` define el aspecto de la interfaz.
-- `script.js` implementa la lógica de creación, renderizado y eliminación de flashcards.
+- `src/app.js` contiene la lógica principal e importa los módulos de almacenamiento y mazos.
 
 Para probar la aplicación solo abre `index.html` en tu navegador.
 

--- a/index.html
+++ b/index.html
@@ -30,6 +30,6 @@
     <button id="clear-all">Eliminar todas</button>
     <ul id="flashcard-list"></ul>
     </div>
-    <script src="script.js"></script>
+    <script type="module" src="src/app.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "proyecto_v1",
   "version": "1.0.0",
   "description": "Esta es una aplicación web sencilla para gestionar flashcards sin utilizar frameworks. Permite crear dos tipos de tarjetas:",
-  "main": "script.js",
+  "main": "src/app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "serve ."

--- a/src/app.js
+++ b/src/app.js
@@ -1,59 +1,5 @@
-// Utilidades para acceder a localStorage
-function loadFlashcards() {
-    const data = localStorage.getItem('flashcards');
-    if (!data) return [];
-    try {
-        return JSON.parse(data);
-    } catch (e) {
-        return [];
-    }
-}
-
-function saveFlashcards(cards) {
-    localStorage.setItem('flashcards', JSON.stringify(cards));
-}
-
-// Manejo de mazos (decks)
-function loadDecks() {
-    const data = localStorage.getItem('decks');
-    if (!data) return ['General'];
-    try {
-        const decks = JSON.parse(data);
-        return decks.length ? decks : ['General'];
-    } catch (e) {
-        return ['General'];
-    }
-}
-
-function saveDecks(decks) {
-    localStorage.setItem('decks', JSON.stringify(decks));
-}
-
-function renderDeckOptions() {
-    const select = document.getElementById('deck');
-    if (!select) return;
-    select.innerHTML = '';
-    loadDecks().forEach(d => {
-        const opt = document.createElement('option');
-        opt.value = d;
-        opt.textContent = d;
-        select.appendChild(opt);
-    });
-}
-
-function addDeck() {
-    const input = document.getElementById('new-deck');
-    const name = input.value.trim();
-    if (!name) return;
-    const decks = loadDecks();
-    if (!decks.includes(name)) {
-        decks.push(name);
-        saveDecks(decks);
-    }
-    input.value = '';
-    renderDeckOptions();
-    document.getElementById('deck').value = name;
-}
+import { loadFlashcards, saveFlashcards } from './storage.js';
+import { loadDecks, saveDecks, renderDeckOptions, addDeck } from './decks.js';
 
 // Índice de tarjeta en modo edición, null si se está creando una nueva
 let editingIndex = null;
@@ -100,18 +46,16 @@ function addFlashcard(event) {
     }
 
     if (editingIndex !== null) {
-        // Si estamos editando, reemplazamos la tarjeta existente
         cards[editingIndex] = card;
         editingIndex = null;
     } else {
-        // Si no, agregamos una nueva
         cards.push(card);
     }
     saveFlashcards(cards);
     renderList();
     event.target.reset();
-    document.getElementById('type').value = type; // mantener selección
-    renderFields(type); // Reiniciar campos según tipo
+    document.getElementById('type').value = type;
+    renderFields(type);
 }
 
 // Elimina una tarjeta por índice
@@ -143,7 +87,6 @@ function editFlashcard(index) {
     const card = cards[index];
     if (!card) return;
 
-    // Establece el tipo y dibuja los campos correspondientes
     const typeSelect = document.getElementById('type');
     typeSelect.value = card.type;
     renderFields(card.type);
@@ -167,7 +110,6 @@ function editFlashcard(index) {
         document.getElementById('isTrue').checked = card.isTrue;
     }
 
-    // Guardamos el índice en edición
     editingIndex = index;
 }
 
@@ -232,7 +174,7 @@ function renderList() {
 function init() {
     const typeSelect = document.getElementById('type');
     renderFields(typeSelect.value);
-    typeSelect.addEventListener('change', (e) => renderFields(e.target.value));
+    typeSelect.addEventListener('change', e => renderFields(e.target.value));
     document.getElementById('flashcard-form').addEventListener('submit', addFlashcard);
     renderDeckOptions();
     const addDeckBtn = document.getElementById('add-deck');

--- a/src/decks.js
+++ b/src/decks.js
@@ -1,0 +1,40 @@
+export function loadDecks() {
+    const data = localStorage.getItem('decks');
+    if (!data) return ['General'];
+    try {
+        const decks = JSON.parse(data);
+        return decks.length ? decks : ['General'];
+    } catch (e) {
+        return ['General'];
+    }
+}
+
+export function saveDecks(decks) {
+    localStorage.setItem('decks', JSON.stringify(decks));
+}
+
+export function renderDeckOptions() {
+    const select = document.getElementById('deck');
+    if (!select) return;
+    select.innerHTML = '';
+    loadDecks().forEach(d => {
+        const opt = document.createElement('option');
+        opt.value = d;
+        opt.textContent = d;
+        select.appendChild(opt);
+    });
+}
+
+export function addDeck() {
+    const input = document.getElementById('new-deck');
+    const name = input.value.trim();
+    if (!name) return;
+    const decks = loadDecks();
+    if (!decks.includes(name)) {
+        decks.push(name);
+        saveDecks(decks);
+    }
+    input.value = '';
+    renderDeckOptions();
+    document.getElementById('deck').value = name;
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,13 @@
+export function loadFlashcards() {
+    const data = localStorage.getItem('flashcards');
+    if (!data) return [];
+    try {
+        return JSON.parse(data);
+    } catch (e) {
+        return [];
+    }
+}
+
+export function saveFlashcards(cards) {
+    localStorage.setItem('flashcards', JSON.stringify(cards));
+}


### PR DESCRIPTION
## Summary
- organize sources under `src/`
- split localStorage helpers into `storage.js`
- extract deck logic into `decks.js`
- keep application logic in `app.js` and load it as an ES module
- update documentation and package entry point

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails: serve not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854af5b53008325b6f7ea76c6bb0a9e