### PR TITLE
Implement deck view and study improvements

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -13,7 +13,8 @@ Cards are stored in `localStorage` so they persist between page reloads.
 - `style.css` visual appearance.
 - `src/app.js` main logic plus storage and deck modules.
 
-To test the application open `index.html` in your browser.
+To test the application you must run a local server (for example `npm start`).
+Because the project uses ES Modules, you cannot open `index.html` directly.
 
 ## Installation
 
@@ -25,3 +26,21 @@ npm start
 ```
 
 This will launch `serve` on the current folder. Open the browser at the address shown in the terminal to use the app.
+
+## Usage
+
+1. Select the card type and fill in the form fields.
+2. Select or create a **deck** to organize your cards.
+3. Click **Save card** to store it.
+4. Each card shows **Edit** and **Delete** buttons:
+   - **Edit** loads the card into the form so you can modify it.
+   - **Delete** removes only that card from the list.
+5. The **Delete all** button removes every card stored in `localStorage`.
+
+## License
+
+This project is distributed under the MIT license. See the `LICENSE` file for details.
+
+## Contributing
+
+Contributions are welcome! If you find a problem or want to propose an improvement, open an issue or send a pull request following the standard GitHub workflow.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Las tarjetas se almacenan en `localStorage` para que persistan entre recargas de
 - `style.css` define el aspecto de la interfaz.
 - `src/app.js` contiene la lógica principal e importa los módulos de almacenamiento y mazos.
 
-Para probar la aplicación solo abre `index.html` en tu navegador.
+Para probar la aplicación necesitas ejecutar un servidor local (por ejemplo `npm start`).
+Al usar módulos ES no es posible abrir `index.html` directamente.
 
 ## Instalación
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <h2>Listado de Flashcards</h2>
     <button id="clear-all">Eliminar todas</button>
     <button id="study-mode">Iniciar estudio</button>
-    <ul id="flashcard-list"></ul>
+    <div id="flashcard-list"></div>
     <div id="study-container" class="hidden"></div>
     </div>
     <script type="module" src="src/app.js"></script>

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ body.dark {
 
 form {
     margin-bottom: 2rem;
-    background-color: #fff;
+    background-color: var(--card-bg);
     padding: 1rem;
     border-radius: 4px;
     box-shadow: 0 0 5px rgba(0,0,0,0.1);
@@ -65,6 +65,25 @@ button {
 
 
 #flashcard-list {
+    list-style-type: none;
+    padding: 0;
+    margin-top: 1rem;
+}
+
+.deck-container {
+    background-color: var(--card-bg);
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    padding: 1rem;
+    margin-bottom: 2rem;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.deck-container h3 {
+    margin-top: 0;
+}
+
+.deck-cards {
     list-style-type: none;
     padding: 0;
     display: grid;
@@ -116,4 +135,12 @@ button {
 
 .hidden{display:none;}
 #study-container{margin-top:1rem;}
+
+.correct {
+    background-color: #c8e6c9;
+}
+
+.incorrect {
+    background-color: #ffcdd2;
+}
 


### PR DESCRIPTION
## Summary
- support card background color in the form
- group cards by deck and show deck containers
- add visual feedback and progress in study mode
- shuffle cards when starting study session
- update README files with local server note

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854b4e0713c83258734be7c98d71d3d