### PR TITLE
Modify clear-all to remove only selected deck

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -35,7 +35,7 @@ This will launch `serve` on the current folder. Open the browser at the address 
 4. Each card shows **Edit** and **Delete** buttons:
    - **Edit** loads the card into the form so you can modify it.
    - **Delete** removes only that card from the list.
-5. The **Delete all** button removes every card stored in `localStorage`.
+5. The **Delete all** button removes only the cards from the selected deck.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Esto iniciará `serve` sobre la carpeta actual. Abre el navegador en la direcci�
 4. En cada tarjeta aparecerán los botones **Editar** y **Eliminar**:
    - **Editar** carga la tarjeta en el formulario para modificarla; al guardar se reemplaza la versión anterior.
    - **Eliminar** borra únicamente esa tarjeta de la lista.
-5. El botón **Eliminar todas** elimina todas las tarjetas guardadas en `localStorage`.
+5. El botón **Eliminar todas** borra únicamente las tarjetas del mazo seleccionado.
 
 ## Licencia
 

--- a/src/app.js
+++ b/src/app.js
@@ -69,8 +69,10 @@ function deleteFlashcard(index) {
 
 // Borra todas las tarjetas almacenadas
 function clearAllFlashcards() {
-    if (!confirm('¿Eliminar todas las tarjetas?')) return;
-    localStorage.removeItem('flashcards');
+    const deck = document.getElementById('deck').value;
+    if (!deck || !confirm(`¿Eliminar todas las tarjetas del mazo "${deck}"?`)) return;
+    const remaining = loadFlashcards().filter(c => c.deck !== deck);
+    saveFlashcards(remaining);
     renderList();
 }
 
@@ -78,7 +80,9 @@ function clearAllFlashcards() {
 function updateClearButton() {
     const btn = document.getElementById('clear-all');
     if (btn) {
-        btn.disabled = loadFlashcards().length === 0;
+        const deck = document.getElementById('deck').value;
+        const hasCards = loadFlashcards().some(c => c.deck === deck);
+        btn.disabled = !hasCards;
     }
 }
 
@@ -290,11 +294,15 @@ function init() {
     renderDeckOptions();
     const addDeckBtn = document.getElementById('add-deck');
     if (addDeckBtn) {
-        addDeckBtn.addEventListener('click', addDeck);
+        addDeckBtn.addEventListener('click', () => { addDeck(); updateClearButton(); });
     }
     const deleteDeckBtn = document.getElementById('delete-deck');
     if (deleteDeckBtn) {
         deleteDeckBtn.addEventListener('click', () => { deleteDeck(); renderList(); });
+    }
+    const deckSelect = document.getElementById('deck');
+    if (deckSelect) {
+        deckSelect.addEventListener('change', updateClearButton);
     }
     const clearBtn = document.getElementById('clear-all');
     if (clearBtn) {


### PR DESCRIPTION
## Summary
- limit *Eliminar todas* button to current deck only
- disable button if selected deck has no cards
- update documentation for new behavior

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854bb9696e48325bb1f5529f2f43748