### PR TITLE
Add responsive navbar and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,32 +7,56 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <nav class="navbar">
+        <div class="nav-brand">Flashcards App</div>
+        <button class="menu-toggle">☰</button>
+        <ul class="nav-links">
+            <li class="dropdown">
+                <a href="#" id="creation-btn">Creación</a>
+                <ul class="dropdown-menu">
+                    <li><a href="#" id="nav-create-card">Carta</a></li>
+                    <li><a href="#" id="nav-create-deck">Mazo</a></li>
+                </ul>
+            </li>
+            <li><a href="#" id="nav-view-decks">Ver Mazos</a></li>
+        </ul>
+        <button id="toggle-theme" type="button">Tema oscuro</button>
+    </nav>
+
     <div class="container">
-    <h1>Gestor de Flashcards</h1>
-    <button id="toggle-theme" type="button">Tema oscuro</button>
+        <section id="card-section" class="view">
+            <h2>Crear Tarjeta</h2>
+            <form id="flashcard-form">
+                <label for="type">Tipo de tarjeta:</label>
+                <select id="type" name="type">
+                    <option value="classic">Clásica</option>
+                    <option value="tf">Falso/Verdadero</option>
+                </select>
+                <label for="deck">Mazo:</label>
+                <select id="deck" name="deck"></select>
+                <div id="dynamic-fields"></div>
+                <button type="submit">Guardar tarjeta</button>
+            </form>
+        </section>
 
-    <form id="flashcard-form">
-        <label for="type">Tipo de tarjeta:</label>
-        <select id="type" name="type">
-            <option value="classic">Clásica</option>
-            <option value="tf">Falso/Verdadero</option>
-        </select>
-        <label for="deck">Mazo:</label>
-        <select id="deck" name="deck"></select>
-        <div class="new-deck">
-            <input type="text" id="new-deck" placeholder="Nuevo mazo">
-            <button type="button" id="add-deck">Añadir</button>
-            <button type="button" id="delete-deck">Eliminar mazo</button>
-        </div>
-        <div id="dynamic-fields"><!-- Campos dinámicos se insertarán aquí --></div>
-        <button type="submit">Guardar tarjeta</button>
-    </form>
+        <section id="deck-section" class="view hidden">
+            <h2>Gestionar Mazos</h2>
+            <label for="deck-manage">Mazo actual:</label>
+            <select id="deck-manage"></select>
+            <div class="new-deck">
+                <input type="text" id="new-deck" placeholder="Nuevo mazo">
+                <button type="button" id="add-deck">Añadir</button>
+                <button type="button" id="delete-deck">Eliminar mazo</button>
+            </div>
+        </section>
 
-    <h2>Listado de Flashcards</h2>
-    <button id="clear-all">Eliminar todas</button>
-    <button id="study-mode">Iniciar estudio</button>
-    <div id="flashcard-list"></div>
-    <div id="study-container" class="hidden"></div>
+        <section id="list-section" class="view hidden">
+            <h2>Mazos</h2>
+            <button id="clear-all">Eliminar todas</button>
+            <button id="study-mode">Iniciar estudio</button>
+            <div id="flashcard-list"></div>
+            <div id="study-container" class="hidden"></div>
+        </section>
     </div>
     <script type="module" src="src/app.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,25 +1,101 @@
 :root {
-    --bg: #f5f5f5;
+    --bg-color: #f5f5f5;
     --card-bg: #fff;
-    --text: #000;
+    --text-color: #000;
+    --navbar-bg: #1976d2;
 }
 
 body {
     font-family: system-ui, sans-serif;
     margin: 2rem;
-    background-color: var(--bg);
-    color: var(--text);
+    background-color: var(--bg-color);
+    color: var(--text-color);
 }
 
 body.dark {
-    --bg: #333;
+    --bg-color: #333;
     --card-bg: #444;
-    --text: #fff;
+    --text-color: #fff;
+}
+
+nav.navbar {
+    position: sticky;
+    top: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: var(--navbar-bg);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.navbar .nav-brand {
+    font-weight: bold;
+}
+
+.navbar .nav-links {
+    list-style: none;
+    display: flex;
+    gap: 1rem;
+    margin: 0;
+    padding: 0;
+}
+
+.navbar a {
+    color: #fff;
+    text-decoration: none;
+}
+
+.dropdown {
+    position: relative;
+}
+
+.dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    display: none;
+    flex-direction: column;
+    background-color: var(--navbar-bg);
+}
+
+.dropdown.open .dropdown-menu,
+.dropdown:hover .dropdown-menu {
+    display: flex;
+}
+
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.5rem;
+}
+
+@media (max-width: 600px) {
+    .navbar .nav-links {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background-color: var(--navbar-bg);
+        flex-direction: column;
+        display: none;
+    }
+
+    .navbar .nav-links.show {
+        display: flex;
+    }
+
+    .menu-toggle {
+        display: block;
+    }
 }
 
 .container {
     max-width: 800px;
-    margin: auto;
+    margin: 1rem auto;
 }
 
 form {
@@ -48,7 +124,7 @@ button {
     cursor: pointer;
     border: none;
     border-radius: 4px;
-    background-color: #1976d2;
+    background-color: var(--navbar-bg);
     color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- implement navigation bar with dropdown menu and theme toggle
- support dark/light theme via CSS variables and localStorage
- add sections for creating cards, managing decks and viewing decks
- update styles for navbar and responsive behavior
- extend JS to handle navigation, theme persistence and deck checks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854bebcc4808325a80d013fc359d760