### PR TITLE
Implement deck card view

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,9 +52,13 @@
 
         <section id="list-section" class="view hidden">
             <h2>Mazos</h2>
-            <button id="clear-all">Eliminar todas</button>
-            <button id="study-mode">Iniciar estudio</button>
-            <div id="flashcard-list"></div>
+            <div id="mazosContainer" class="mazos-grid"></div>
+            <div id="tarjetasDelMazo" class="hidden">
+                <button type="button" id="back-to-mazos">Volver</button>
+                <button id="clear-all">Eliminar todas</button>
+                <button id="study-mode">Iniciar estudio</button>
+                <div id="flashcard-list"></div>
+            </div>
             <div id="study-container" class="hidden"></div>
         </section>
     </div>

--- a/style.css
+++ b/style.css
@@ -168,6 +168,28 @@ button {
     margin-top: 1rem;
 }
 
+.mazos-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+}
+
+.mazo-card {
+    background-color: var(--card-bg);
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 1rem;
+    text-align: center;
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.mazo-card:hover {
+    transform: scale(1.05);
+}
+
 
 
 .flashcard {


### PR DESCRIPTION
## Summary
- add containers for deck card view
- style deck and card elements
- show decks as cards and display cards per deck on click

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854c22afd348325904f4ef830915e0a