### PR TITLE
Improve server and add tests

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@ Alternatively you can start the included server with `npm start`.
 
 ## Installation
 
-Install Node.js and the project dependencies:
+Requires **Node.js 18 or higher**. Then install the project dependencies:
 
 ```bash
 npm install

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Si lo prefieres, también puedes iniciar un servidor local con `npm start`.
 
 ## Instalación
 
-Instala Node.js y las dependencias del proyecto:
+Requiere **Node.js 18 o superior**. Después instala las dependencias del proyecto:
+Instala las dependencias ejecutando:
 
 ```bash
 npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "proyecto_v1",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "proyecto_v1",
+      "version": "1.0.0",
+      "license": "MIT"
+    }
+  }
+}

--- a/server.js
+++ b/server.js
@@ -31,7 +31,8 @@ function logRequest(req) {
 
 async function handler(req, res) {
   logRequest(req);
-  const urlPath = decodeURIComponent(req.url === '/' ? '/index.html' : req.url);
+  const { pathname } = new URL(req.url, 'http://localhost');
+  const urlPath = decodeURIComponent(pathname === '/' ? '/index.html' : pathname);
   const safePath = resolve(join(root, '.' + urlPath));
   if (!safePath.startsWith(root)) {
     res.writeHead(403, securityHeaders);

--- a/test/decks-storage.test.js
+++ b/test/decks-storage.test.js
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  loadDecks,
+  saveDecks,
+  addDeck,
+  deleteDeck
+} from '../src/decks.js';
+import { loadFlashcards, saveFlashcards } from '../src/storage.js';
+
+function createLocalStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = value;
+    },
+    removeItem(key) {
+      delete store[key];
+    },
+    clear() {
+      for (const k of Object.keys(store)) delete store[k];
+    }
+  };
+}
+
+function setupDOM() {
+  const elements = {
+    'new-deck': { value: '' },
+    'deck': {
+      value: '',
+      innerHTML: '',
+      children: [],
+      appendChild(child) {
+        this.children.push(child);
+      }
+    }
+  };
+  global.document = {
+    elements,
+    getElementById(id) {
+      return this.elements[id] || null;
+    },
+    createElement() {
+      return { value: '', textContent: '', appendChild() {} };
+    }
+  };
+}
+
+test('loadDecks and saveDecks roundtrip', () => {
+  global.localStorage = createLocalStorage();
+  saveDecks(['General', 'Extra']);
+  assert.deepStrictEqual(loadDecks(), ['General', 'Extra']);
+});
+
+test('addDeck stores new deck and updates input', () => {
+  global.localStorage = createLocalStorage({ decks: JSON.stringify(['General']) });
+  setupDOM();
+  global.document.getElementById('new-deck').value = 'Extra';
+  addDeck();
+  assert.deepStrictEqual(loadDecks(), ['General', 'Extra']);
+  assert.strictEqual(global.document.getElementById('new-deck').value, '');
+  assert.strictEqual(global.document.getElementById('deck').value, 'Extra');
+});
+
+test('deleteDeck removes deck and related cards', () => {
+  global.localStorage = createLocalStorage({
+    decks: JSON.stringify(['General', 'Extra']),
+    flashcards: JSON.stringify([
+      { deck: 'Extra', q: 1 },
+      { deck: 'General', q: 2 }
+    ])
+  });
+  setupDOM();
+  global.document.getElementById('deck').value = 'Extra';
+  global.confirm = () => true;
+  deleteDeck();
+  assert.deepStrictEqual(loadDecks(), ['General']);
+  assert.deepStrictEqual(loadFlashcards(), [{ deck: 'General', q: 2 }]);
+  assert.strictEqual(global.document.getElementById('deck').value, 'General');
+});
+
+test('loadFlashcards and saveFlashcards roundtrip', () => {
+  global.localStorage = createLocalStorage();
+  const cards = [{ q: 'q1', a: 'a1' }];
+  saveFlashcards(cards);
+  assert.deepStrictEqual(loadFlashcards(), cards);
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -2,11 +2,38 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { createServer } from '../server.js';
 
-test('GET / returns 200', async () => {
+async function startServer() {
   const server = createServer();
   await new Promise(resolve => server.listen(0, resolve));
   const { port } = server.address();
-  const res = await fetch(`http://localhost:${port}/`);
+  const url = `http://localhost:${port}`;
+  return { server, url };
+}
+
+test('GET / returns 200', async () => {
+  const { server, url } = await startServer();
+  const res = await fetch(`${url}/`);
   assert.strictEqual(res.status, 200);
+  server.close();
+});
+
+test('GET /index.html?x=1 returns 200', async () => {
+  const { server, url } = await startServer();
+  const res = await fetch(`${url}/index.html?x=1`);
+  assert.strictEqual(res.status, 200);
+  server.close();
+});
+
+test('GET /nope.html returns 404', async () => {
+  const { server, url } = await startServer();
+  const res = await fetch(`${url}/nope.html`);
+  assert.strictEqual(res.status, 404);
+  server.close();
+});
+
+test('GET /../package.json is forbidden', async () => {
+  const { server, url } = await startServer();
+  const res = await fetch(`${url}/..%2Fpackage.json`);
+  assert.strictEqual(res.status, 403);
   server.close();
 });


### PR DESCRIPTION
## Summary
- ignore query strings when resolving server paths
- update documentation for Node 18 requirement
- add package-lock for reproducible installs
- add extensive server and module tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ecaa5ce88325afeaff6b5f001114