### PR TITLE
Add import/export feature for flashcards

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -53,6 +53,12 @@ npm test
    - **Delete** removes only that card from the list.
 5. The **Delete all** button removes only the cards from the selected deck.
 
+## Backups
+
+Inside the deck management section you will find **Import** and **Export** buttons.
+**Export** downloads a JSON file containing all your decks and cards, while
+**Import** restores that information from a similar file.
+
 ## License
 
 This project is distributed under the MIT license. See the `LICENSE` file for details.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ npm test
    - **Eliminar** borra únicamente esa tarjeta de la lista.
 5. El botón **Eliminar todas** borra únicamente las tarjetas del mazo seleccionado.
 
+## Copias de seguridad
+
+En la sección de gestión de mazos dispones de los botones **Importar** y **Exportar**.
+**Exportar** descarga un archivo JSON con todos tus mazos y tarjetas, mientras que
+**Importar** permite restaurar esa información desde un archivo similar.
+
 ## Licencia
 
 Este proyecto se distribuye bajo la licencia MIT. Consulta el archivo `LICENSE` para más detalles.

--- a/index.html
+++ b/index.html
@@ -50,6 +50,10 @@
                 <button type="button" id="add-deck">Añadir</button>
                 <button type="button" id="delete-deck">Eliminar mazo</button>
             </div>
+            <div class="backup">
+                <button type="button" id="import-data">Importar</button>
+                <button type="button" id="export-data">Exportar</button>
+            </div>
         </section>
 
         <section id="list-section" class="view hidden">

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ import { initTheme, toggleTheme } from "./theme.js";
 import { startStudyMode } from "./study.js";
 import { loadFlashcards, saveFlashcards } from './storage.js';
 import { loadDecks, saveDecks, renderDeckOptions, addDeck, deleteDeck } from './decks.js';
+import { exportData, importData } from './backup.js';
 
 // Índice de tarjeta en modo edición, null si se está creando una nueva
 let editingIndex = null;
@@ -460,6 +461,43 @@ function init() {
     const themeBtn = document.getElementById('toggle-theme');
     if (themeBtn) {
         themeBtn.addEventListener('click', toggleTheme);
+    }
+    const exportBtn = document.getElementById('export-data');
+    if (exportBtn) {
+        exportBtn.addEventListener('click', () => {
+            const blob = new Blob([exportData()], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'flashcards.json';
+            a.click();
+            URL.revokeObjectURL(url);
+        });
+    }
+    const importBtn = document.getElementById('import-data');
+    if (importBtn) {
+        importBtn.addEventListener('click', () => {
+            const input = document.createElement('input');
+            input.type = 'file';
+            input.accept = 'application/json';
+            input.addEventListener('change', () => {
+                const file = input.files[0];
+                if (!file) return;
+                const reader = new FileReader();
+                reader.onload = () => {
+                    if (importData(reader.result)) {
+                        updateDeckSelects();
+                        renderList();
+                        renderMazos();
+                        showCardMessage('Datos importados');
+                    } else {
+                        alert('Archivo inválido');
+                    }
+                };
+                reader.readAsText(file);
+            });
+            input.click();
+        });
     }
     const studyBtn = document.getElementById('study-mode');
     if (studyBtn) {

--- a/src/backup.js
+++ b/src/backup.js
@@ -1,0 +1,25 @@
+import { loadFlashcards, saveFlashcards } from './storage.js';
+import { loadDecks, saveDecks } from './decks.js';
+
+export function exportData() {
+  const data = {
+    decks: loadDecks(),
+    flashcards: loadFlashcards()
+  };
+  return JSON.stringify(data, null, 2);
+}
+
+export function importData(json) {
+  let data;
+  try {
+    data = JSON.parse(json);
+  } catch {
+    return false;
+  }
+  if (!data || !Array.isArray(data.decks) || !Array.isArray(data.flashcards)) {
+    return false;
+  }
+  saveDecks(data.decks.length ? data.decks : ['General']);
+  saveFlashcards(data.flashcards);
+  return true;
+}

--- a/style.css
+++ b/style.css
@@ -170,6 +170,12 @@ button:hover {
     flex: 1;
 }
 
+.backup {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
 
 #flashcard-list {
     list-style-type: none;

--- a/test/backup.test.js
+++ b/test/backup.test.js
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { exportData, importData } from '../src/backup.js';
+import { loadDecks, saveDecks } from '../src/decks.js';
+import { loadFlashcards, saveFlashcards } from '../src/storage.js';
+
+function createLocalStorage(initial = {}) {
+  const store = { ...initial };
+  return {
+    getItem(key) {
+      return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = value;
+    },
+    removeItem(key) {
+      delete store[key];
+    },
+    clear() {
+      for (const k of Object.keys(store)) delete store[k];
+    }
+  };
+}
+
+test('exportData returns JSON with decks and flashcards', () => {
+  global.localStorage = createLocalStorage({
+    decks: JSON.stringify(['General']),
+    flashcards: JSON.stringify([{ q: 'q1' }])
+  });
+  const json = exportData();
+  assert.deepStrictEqual(JSON.parse(json), {
+    decks: ['General'],
+    flashcards: [{ q: 'q1' }]
+  });
+});
+
+test('importData restores decks and flashcards', () => {
+  global.localStorage = createLocalStorage();
+  const ok = importData(JSON.stringify({
+    decks: ['General', 'Extra'],
+    flashcards: [{ q: 1 }]
+  }));
+  assert.strictEqual(ok, true);
+  assert.deepStrictEqual(loadDecks(), ['General', 'Extra']);
+  assert.deepStrictEqual(loadFlashcards(), [{ q: 1 }]);
+});


### PR DESCRIPTION
## Summary
- add backup module with `exportData` and `importData`
- integrate import/export buttons in the UI
- handle backup events in the app logic
- style new backup section
- document the new feature in both README files
- add tests for backup module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854ef7d7b588325910f6a07ea2c0891