### PR TITLE
Add search and Spanish docs for PHP inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ En la sección de gestión de mazos dispones de los botones **Importar** y **Exp
 **Importar** permite restaurar esa información desde un archivo similar.
 ## Sistema de Inventario (PHP)
 
-Consulta la carpeta `inventory` para un ejemplo basico de gestion de productos con PHP y MySQL. Ejecuta `schema.sql` en tu servidor MySQL y abre `index.php` desde XAMPP.
+En la carpeta `inventory` encontrarás un sistema sencillo para administrar el stock de una tienda utilizando **PHP**, **MySQL** y un poco de **JavaScript**.
+Para ponerlo en marcha sigue estos pasos:
+
+1. Copia la carpeta en `htdocs` de tu instalación de **XAMPP**.
+2. Importa `schema.sql` en MySQL para crear la base de datos `inventario_db`.
+3. Ajusta las credenciales en `db.php` si fuera necesario.
+4. Abre `http://localhost/inventory/index.php` desde tu navegador.
+
+La página principal permite agregar, editar y eliminar productos. Incluye un campo de búsqueda para filtrar la lista y confirmaciones de eliminación implementadas en JavaScript.
 
 ## Licencia
 

--- a/inventory/README.md
+++ b/inventory/README.md
@@ -1,15 +1,36 @@
-# Inventory System (PHP)
+# Sistema de Inventario en PHP
 
-This folder contains a minimal inventory system built with PHP and MySQL.
-It is designed to run on a local XAMPP server.
+Este directorio contiene un ejemplo sencillo de sistema de inventario pensado para ejecutarse en un servidor local XAMPP.
 
-## Setup
+## Requisitos
 
-1. Install **XAMPP** and start the Apache and MySQL services.
-2. Import `schema.sql` using phpMyAdmin or the MySQL command line to create the
-   database `inventario_db` and the table `productos`.
-3. Copy this folder into the `htdocs` directory of XAMPP.
-4. Adjust the database credentials in `db.php` if necessary.
-5. Open `http://localhost/inventory/index.php` in your browser.
+- **XAMPP** con los servicios de Apache y MySQL activos.
+- PHP 7 o superior.
 
-The main page allows you to add, edit and delete products.
+## Instalación
+
+1. Copia la carpeta `inventory` dentro del directorio `htdocs` de XAMPP.
+2. Crea la base de datos ejecutando el script `schema.sql` en phpMyAdmin o desde la consola de MySQL.
+3. Ajusta las credenciales de `db.php` si es necesario.
+4. Abre `http://localhost/inventory/index.php` en tu navegador.
+
+## Uso
+
+Desde la página principal podrás añadir, editar y eliminar productos.
+Utiliza el campo de **buscar** para filtrar la lista por nombre y confirma la eliminación de cada registro mediante la ventana emergente.
+
+## Estructura de archivos
+
+- `index.php` pantalla principal con el listado y formulario de alta.
+- `add_product.php` guarda un nuevo producto en la base de datos.
+- `edit.php` carga el formulario para editar un producto existente.
+- `edit_product.php` actualiza la información editada.
+- `delete_product.php` elimina un producto.
+- `db.php` configuración de conexión a MySQL.
+- `schema.sql` crea la base de datos `inventario_db` y la tabla `productos`.
+- `styles.css` estilos básicos.
+- `script.js` funciones en JavaScript para búsqueda y confirmaciones.
+
+## Licencia
+
+Este proyecto se distribuye bajo la licencia MIT.

--- a/inventory/index.php
+++ b/inventory/index.php
@@ -27,7 +27,8 @@ $products = fetch_products($mysqli);
     </form>
 
     <h2>Lista de Productos</h2>
-    <table>
+    <input type="text" id="search" placeholder="Buscar por nombre...">
+    <table id="product-table">
         <thead>
             <tr>
                 <th>ID</th>
@@ -46,11 +47,12 @@ $products = fetch_products($mysqli);
                 <td><?php echo $p['precio']; ?></td>
                 <td>
                     <a href="edit.php?id=<?php echo $p['id']; ?>">Editar</a>
-                    <a href="delete_product.php?id=<?php echo $p['id']; ?>" onclick="return confirm('¿Eliminar?');">Eliminar</a>
+                    <a class="delete-link" href="delete_product.php?id=<?php echo $p['id']; ?>">Eliminar</a>
                 </td>
             </tr>
             <?php endforeach; ?>
         </tbody>
     </table>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/inventory/script.js
+++ b/inventory/script.js
@@ -1,0 +1,19 @@
+const table = document.getElementById('product-table');
+const search = document.getElementById('search');
+const deleteLinks = document.querySelectorAll('.delete-link');
+
+search.addEventListener('input', () => {
+  const term = search.value.toLowerCase();
+  for (const row of table.tBodies[0].rows) {
+    const name = row.cells[1].textContent.toLowerCase();
+    row.style.display = name.includes(term) ? '' : 'none';
+  }
+});
+
+for (const link of deleteLinks) {
+  link.addEventListener('click', event => {
+    if (!confirm('¿Eliminar este producto?')) {
+      event.preventDefault();
+    }
+  });
+}

--- a/inventory/styles.css
+++ b/inventory/styles.css
@@ -7,6 +7,11 @@ table {
     width: 100%;
     margin-top: 10px;
 }
+#search {
+    margin-top: 10px;
+    padding: 6px;
+    width: 50%;
+}
 th, td {
     border: 1px solid #ccc;
     padding: 8px;


### PR DESCRIPTION
## Summary
- add search box and JS filter to PHP inventory
- confirm deletion via JavaScript
- style search input
- translate inventory documentation to Spanish
- extend root README with XAMPP setup instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b0120d12c83258fa6ece9f53ffc76